### PR TITLE
♻️ Refactor `payload_hashed` to Use `cast hash-message`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ TOKEN_CONTRACT="0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
 ```
 
 > [!TIP]
-> When submitting bundles to Flashbots, they are signed with your `FLASHBOTS_SIGNATURE_PK` key, enabling Flashbots to verify your identity and track your [reputation](https://docs.flashbots.net/flashbots-auction/advanced/reputation) over time. This reputation system is designed to safeguard the infrastructure from threats such as DDoS attacks. It's important to note that this key **does not** handle any funds and is **not** required to be the primary Ethereum key used for transaction authentication. Its sole purpose is to establish your identity with Flashbots. You can use any ECDSA-secp256k1 key for this, and if you need to create a new one, you can use [`cast wallet new`](https://book.getfoundry.sh/reference/cast/cast-wallet-new).
+> When submitting bundles to Flashbots, they are signed with your `FLASHBOTS_SIGNATURE_PK` key, enabling Flashbots to verify your identity and track your [reputation](https://docs.flashbots.net/flashbots-auction/advanced/reputation) over time. This reputation system is designed to safeguard the infrastructure from threats such as DDoS attacks. It's important to note that this key **does not** handle any funds and is **not** required to be the primary Ethereum key used for transaction authentication. Its sole purpose is to establish your identity with Flashbots. You can use any ECDSA `secp256k1` key for this, and if you need to create a new one, you can use [`cast wallet new`](https://book.getfoundry.sh/reference/cast/cast-wallet-new).
 
 Finally, execute the script:
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # White Hat Frontrunning
 
-White hat frontrunning [script](./go.sh) to outpace hackers and secure funds from compromised wallets. The (Bash) script is intentionally designed with minimal dependencies, requiring only the native tools provided by Linux and [`cast`](https://github.com/foundry-rs/foundry/tree/master/crates/cast) & [`chisel`](https://github.com/foundry-rs/foundry/tree/master/crates/chisel) from [Foundry](https://github.com/foundry-rs/foundry).
+White hat frontrunning [script](./go.sh) to outpace hackers and secure funds from compromised wallets. The (Bash) script is intentionally designed with minimal dependencies, requiring only the native tools provided by Linux and [`cast`](https://github.com/foundry-rs/foundry/tree/master/crates/cast) from [Foundry](https://github.com/foundry-rs/foundry).
 
 ## Usage
 
 > [!NOTE]
-> Ensure that `cast` and `chisel` are installed locally. For installation instructions, refer to this [guide](https://book.getfoundry.sh/getting-started/installation).
+> Ensure that `cast` are installed locally. For installation instructions, refer to this [guide](https://book.getfoundry.sh/getting-started/installation).
 
 First, modify the main loop in the [script](./go.sh). At present, it's set to send gas to a victim wallet and transfer a specific token. Since the main loop needs to be tailored for each rescue, please review and adjust it carefully.
 
@@ -28,6 +28,9 @@ GAS_PK="0x9876543210"
 FLASHBOTS_SIGNATURE_PK="0x31337"
 TOKEN_CONTRACT="0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
 ```
+
+> [!TIP]
+> When submitting bundles to Flashbots, they are signed with your `FLASHBOTS_SIGNATURE_PK` key, enabling Flashbots to verify your identity and track your [reputation](https://docs.flashbots.net/flashbots-auction/advanced/reputation) over time. This reputation system is designed to safeguard the infrastructure from threats such as DDoS attacks. It's important to note that this key **does not** handle any funds and is **not** required to be the primary Ethereum key used for transaction authentication. Its sole purpose is to establish your identity with Flashbots. You can use any ECDSA-secp256k1 key for this, and if you need to create a new one, you can use [`cast wallet new`](https://book.getfoundry.sh/reference/cast/cast-wallet-new).
 
 Finally, execute the script:
 

--- a/go.sh
+++ b/go.sh
@@ -65,7 +65,7 @@ create_flashbots_signature() {
     local payload="$1"
     local private_key="$2"
     local payload_keccak=$(cast keccak "$payload")
-    local payload_hashed=$(chisel eval 'keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n66","'$payload_keccak'"))' | awk '/Data:/ {gsub(/\x1b\[[0-9;]*m/, "", $3); print $3}')
+    local payload_hashed=$(cast hash-message "$payload_keccak")
     local signature=$(cast wallet sign "$payload_hashed" --private-key "$private_key" --no-hash | tr -d '\n')
     echo "$signature"
 }


### PR DESCRIPTION
### 🕓 Changelog

Refactor to use `cast hash-message` directly, deprecating the need for `chisel` (see [PR #9130](https://github.com/foundry-rs/foundry/pull/9130)). Additionally, include a note highlighting the need to set the `FLASHBOTS_SIGNATURE_PK` environment variable for proper functionality.